### PR TITLE
chore(deps): update @types/node to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@ffflorian/eslint-config": "0.10.3",
     "@ffflorian/prettier-config": "0.3.3",
     "@type-challenges/utils": "0.1.1",
-    "@types/node": "~20",
+    "@types/node": "~22",
     "@typescript-eslint/eslint-plugin": "8.12.2",
     "@typescript-eslint/parser": "8.12.2",
     "babel-eslint": "10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,7 +294,7 @@ __metadata:
     "@ffflorian/eslint-config": 0.10.3
     "@ffflorian/prettier-config": 0.3.3
     "@type-challenges/utils": 0.1.1
-    "@types/node": ~20
+    "@types/node": ~22
     "@typescript-eslint/eslint-plugin": 8.12.2
     "@typescript-eslint/parser": 8.12.2
     babel-eslint: 10.1.0
@@ -527,12 +527,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~20":
-  version: 20.16.11
-  resolution: "@types/node@npm:20.16.11"
+"@types/node@npm:~22":
+  version: 22.8.7
+  resolution: "@types/node@npm:22.8.7"
   dependencies:
-    undici-types: ~6.19.2
-  checksum: 68a239e4cff66972c990a89faa052da27d17d9f8d3ee324e9e5899323feaf229b475c1969ae9e189d0c499736fc04e9f20f480613d16b93ce249518dc32707a0
+    undici-types: ~6.19.8
+  checksum: c7b200d06da97a4d4f46528ae962c028bb06b6ef9ab7f7949639420f3b3d236f041756ca1945dcaec0fcefbafd07b8ca47bbc1b47b77d33a4173211425641426
   languageName: node
   linkType: hard
 
@@ -3222,7 +3222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.2":
+"undici-types@npm:~6.19.8":
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: de51f1b447d22571cf155dfe14ff6d12c5bdaec237c765085b439c38ca8518fc360e88c70f99469162bf2e14188a7b0bcb06e1ed2dc031042b984b0bb9544017


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `@types/node` package version for improved type definitions and compatibility with newer Node.js features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->